### PR TITLE
Implementes the Resource Owner Password Credentials Grant

### DIFF
--- a/authServer/context.js
+++ b/authServer/context.js
@@ -37,6 +37,7 @@ exports.httpOAuthContext = function (req) {
 		password: getParam('password'),
 		scope: getParam('scope') ? getParam('scope').split(',') : null,
 		redirectUri: getParam('redirect_uri'),
-		accessToken: getAccessToken()
+		accessToken: getAccessToken(),
+		userName: getParam('username')
 	} : null;
 };

--- a/authServer/index.js
+++ b/authServer/index.js
@@ -91,7 +91,7 @@ AuthServer.prototype.getTokenData = function(context, callback) {
 		});
 	}
 	else if (grantType === grantTypes.password) {
-		self.membershipService.areUserCredentialsValid(userId, context.password, function(isValidPassword) {
+		self.membershipService.areUserCredentialsValid(context.userName, context.password, function(isValidPassword) {
 			var tokenData = isValidPassword ? generateTokenDataRef(true) : errors.invalidUserCredentials(context.state);
 			return callback(tokenData);
 		});

--- a/examples/basic/server.js
+++ b/examples/basic/server.js
@@ -11,11 +11,21 @@ var authCodes = {},
 			secret: 'what',
 			grantTypes: ['implicit', 'password', 'client_credentials', 'authorization_code'],
 			isValidRedirectUri: function(uri) { return true; }
+		},
+		'dummy': {
+			id: 'dummy',
+			secret: '',
+			grantTypes: ['password'],
+			isValidRedirectUri: function(uri) { return true; }
 		}
 	},
 	clientService = {
 		getById: function(id, callback) {
-			return callback(clients[id]);
+			if (id === null) {
+				return callback(clients['dummy']);
+			} else {
+				return callback(clients[id]);
+			}
 		}
 	},
 	tokenService = {
@@ -40,7 +50,7 @@ var authCodes = {},
 		}
 	},
 	membershipService = {
-		areUserCredentialsValid: function(userId, password, callback) {
+		areUserCredentialsValid: function(userName, password, callback) {
 			return callback(true);
 		}
 	},

--- a/test/context.js
+++ b/test/context.js
@@ -12,7 +12,8 @@ describe('httpOAuthContext', function() {
 				state: 'mystate',
 				password: 'mypassword',
 				scope: 'scope1,scope2,scope3',
-				redirect_uri: 'http://someredirect.com'
+				redirect_uri: 'http://someredirect.com',
+				username: 'test'
 			},
 			headers: {
 				authorization: 'Authorization: Bearer myaccesstoken'
@@ -69,5 +70,9 @@ describe('httpOAuthContext', function() {
 
 	it ('has the correct access token with a complete request', function() {
 		expect(httpOAuthContext(completeRequest).accessToken).to.equal('myaccesstoken');
+	});
+	
+	it ('has the correct username with a complete request', function() {
+		expect(httpOAuthContext(completeRequest).userName).to.equal('test');
 	});
 });


### PR DESCRIPTION
- According to http://tools.ietf.org/html/draft-ietf-oauth-v2-29#section-4.3 the request needs no 'client_id' so the workaround on the server side is to pass in a dummy client object which just grants the password type.
- Also fixed the typeof comparison of undefined.
