### PR TITLE
Move redirect uri validation function into client service.

### DIFF
--- a/authServer/index.js
+++ b/authServer/index.js
@@ -37,7 +37,7 @@ AuthServer.prototype.authorizeRequest = function(req, userId, callback) {
 	var authorizeRequestWithClient = function(client) {
 		if (!client)
 			return callback(errors.invalidClient(context));
-		else if (!context.redirectUri || !client.isValidRedirectUri(context.redirectUri))
+		else if (!context.redirectUri || !self.clientService.isValidRedirectUri(client,context.redirectUri))
 			return callback(errors.redirectUriMismatch(context.state));
 
 		if (!self.isSupportedScope(context.scope))

--- a/examples/basic/server.js
+++ b/examples/basic/server.js
@@ -9,14 +9,12 @@ var authCodes = {},
 		'1': {
 			id: '1',
 			secret: 'what',
-			grantTypes: ['implicit', 'password', 'client_credentials', 'authorization_code'],
-			isValidRedirectUri: function(uri) { return true; }
+			grantTypes: ['implicit', 'password', 'client_credentials', 'authorization_code']
 		},
 		'dummy': {
 			id: 'dummy',
 			secret: '',
-			grantTypes: ['password'],
-			isValidRedirectUri: function(uri) { return true; }
+			grantTypes: ['password']
 		}
 	},
 	clientService = {
@@ -26,7 +24,8 @@ var authCodes = {},
 			} else {
 				return callback(clients[id]);
 			}
-		}
+		},
+		isValidRedirectUri: function(client,uri) { return true; }
 	},
 	tokenService = {
 		generateToken: function() { 


### PR DESCRIPTION
Practically, storing a function against each individual client, while seemingly a good idea, isn't that practical for most storage solutions. Better to pass in the client data, along with the URI, into a generic validation function.
