### PR TITLE
bug fix.

### DIFF
--- a/lib/authServer.js
+++ b/lib/authServer.js
@@ -148,7 +148,7 @@ internals.AuthServer.prototype.getTokenData = function (context, userId, callbac
         });
     }
     else if (grantType === GrantTypes.password) {
-        self.membershipService.areUserCredentialsValid(context.userName, context.password, context.scope, function (isValidPassword) {
+        return self.membershipService.areUserCredentialsValid(context.userName, context.password, context.scope, function (isValidPassword) {
 
             var tokenData = isValidPassword ? generateTokenDataRef(true) : Errors.invalidUserCredentials(context.state);
             return callback(tokenData);


### PR DESCRIPTION
is there a little bug. when using 'password' grant type.

`return callback(Errors.unsupportedGrantType(context.state)); `

callback function running two times, because 151 line has no returns. 
