### PR TITLE
prevent double callback in getTokenData()

### DIFF
--- a/lib/authServer.js
+++ b/lib/authServer.js
@@ -141,7 +141,7 @@ internals.AuthServer.prototype.getTokenData = function (context, userId, callbac
     };
 
     if (grantType === GrantTypes.authorizationCode) {
-        AuthUtil.isValidAuthorizationCode(context, self.authorizationService, function (isValidAuthCode) {
+        return AuthUtil.isValidAuthorizationCode(context, self.authorizationService, function (isValidAuthCode) {
 
             var tokenData = isValidAuthCode ? generateTokenDataRef(true) : Errors.invalidAuthorizationCode(context.state);
             return callback(tokenData);


### PR DESCRIPTION
In `internals.AuthServer.prototype.getTokenData()`, if the grant type is `authorization_code`, the callback is invoked twice. This commit fixes that by adding the necessary return statement.